### PR TITLE
Error handling

### DIFF
--- a/Data/GraphQL.hs
+++ b/Data/GraphQL.hs
@@ -1,5 +1,7 @@
 module Data.GraphQL where
 
+import Control.Applicative (Alternative)
+
 import Data.Text (Text)
 
 import qualified Data.Aeson as Aeson
@@ -10,13 +12,12 @@ import Data.GraphQL.Parser
 import Data.GraphQL.Schema
 
 import Data.GraphQL.Error
-import Control.Monad (MonadPlus)
 
-graphql :: (MonadPlus m, Monad m) => Schema m -> Text -> m Aeson.Value
+graphql :: (Alternative m, Monad m) => Schema m -> Text -> m Aeson.Value
 graphql = flip graphqlSubs $ const Nothing
 
 
-graphqlSubs :: (MonadPlus m, Monad m) => Schema m -> Subs -> Text -> m Aeson.Value
+graphqlSubs :: (Alternative m, Monad m) => Schema m -> Subs -> Text -> m Aeson.Value
 graphqlSubs schema f =
     either parseError (execute schema f)
   . Attoparsec.parseOnly document

--- a/Data/GraphQL.hs
+++ b/Data/GraphQL.hs
@@ -11,10 +11,13 @@ import Data.GraphQL.Execute
 import Data.GraphQL.Parser
 import Data.GraphQL.Schema
 
+import Data.GraphQL.Error
+
 graphql :: (Alternative m, Monad m) => Schema m -> Text -> m Aeson.Value
 graphql = flip graphqlSubs $ const Nothing
 
+
 graphqlSubs :: (Alternative m, Monad m) => Schema m -> Subs -> Text -> m Aeson.Value
 graphqlSubs schema f =
-    either (const empty) (execute schema f)
+    either parseError (execute schema f)
   . Attoparsec.parseOnly document

--- a/Data/GraphQL.hs
+++ b/Data/GraphQL.hs
@@ -1,7 +1,5 @@
 module Data.GraphQL where
 
-import Control.Applicative (Alternative, empty)
-
 import Data.Text (Text)
 
 import qualified Data.Aeson as Aeson
@@ -12,12 +10,13 @@ import Data.GraphQL.Parser
 import Data.GraphQL.Schema
 
 import Data.GraphQL.Error
+import Control.Monad (MonadPlus)
 
-graphql :: (Alternative m, Monad m) => Schema m -> Text -> m Aeson.Value
+graphql :: (MonadPlus m, Monad m) => Schema m -> Text -> m Aeson.Value
 graphql = flip graphqlSubs $ const Nothing
 
 
-graphqlSubs :: (Alternative m, Monad m) => Schema m -> Subs -> Text -> m Aeson.Value
+graphqlSubs :: (MonadPlus m, Monad m) => Schema m -> Subs -> Text -> m Aeson.Value
 graphqlSubs schema f =
     either parseError (execute schema f)
   . Attoparsec.parseOnly document

--- a/Data/GraphQL/Error.hs
+++ b/Data/GraphQL/Error.hs
@@ -5,54 +5,50 @@ module Data.GraphQL.Error (
   addErr,
   addErrMsg,
   runCollectErrs,
-  runAppendErrs,
-  lift
+  joinErrs,
+  errWrap
   ) where
 
 import qualified Data.Aeson as Aeson
 import Data.Text (Text, pack)
 
-import Control.Monad.State (StateT, lift, modify, runStateT)
+import Control.Arrow ((&&&))
 
-parseError :: Applicative m => String -> m Aeson.Value
+
+-- | Wraps a parse error into a list of errors.
+parseError :: Applicative f => String -> f Aeson.Value
 parseError s =
   pure $ Aeson.object [("errors", Aeson.toJSON [makeErrorMsg $ pack s])]
 
-type CollectErrsT m = StateT [Aeson.Value] m
+type CollectErrsT f a = f (a,[Aeson.Value])
 
-runCollectErrsT :: Monad m
-                   => CollectErrsT m a
-                   -> [Aeson.Value] -> m (a, [Aeson.Value])
-runCollectErrsT = runStateT
+
+joinErrs
+  :: (Applicative m, Functor f, Foldable f)
+  => m (f (a,[Aeson.Value])) -> CollectErrsT m (f a)
+joinErrs = fmap $ fmap fst &&& concatMap snd
+
+-- | Wraps the given applicative to handle errors
+errWrap :: Applicative f => f a -> f (a, [Aeson.Value])
+errWrap = fmap (flip (,) [])
 
 -- | Adds an error to the list of errors.
-addErr :: Monad m => Aeson.Value -> CollectErrsT m ()
-addErr v = modify (v :)
+addErr :: Applicative f => Aeson.Value -> CollectErrsT f a -> CollectErrsT f a
+addErr v = (fmap . fmap) (v :)
 
 makeErrorMsg :: Text -> Aeson.Value
 makeErrorMsg s = Aeson.object [("message",Aeson.toJSON s)]
 
 -- | Convenience function for just wrapping an error message.
-addErrMsg :: Monad m => Text -> CollectErrsT m ()
+addErrMsg :: Applicative f => Text -> CollectErrsT f a -> CollectErrsT f a
 addErrMsg = addErr . makeErrorMsg
-
--- | Appends the given list of errors to the current list of errors.
-appendErrs :: Monad m => [Aeson.Value] -> CollectErrsT m ()
-appendErrs errs = modify (errs ++)
 
 -- | Runs the given query computation, but collects the errors into an error
 --  list, which is then sent back with the data.
-runCollectErrs :: Monad m => CollectErrsT m Aeson.Value -> m (Aeson.Value)
-runCollectErrs res = do
-  (dat,errs) <- runCollectErrsT res []
-  if null errs
-    then return $ Aeson.object [("data",dat)]
-    else return $ Aeson.object [("data",dat),("errors",Aeson.toJSON $ reverse errs)]
-
--- | Runs the given computation, collecting the errors and appending them
---   to the previous list of error.
-runAppendErrs :: Monad m => CollectErrsT m a -> CollectErrsT m a
-runAppendErrs f = do
-  (v, errs) <- lift $ runCollectErrsT f []
-  appendErrs errs
-  return v
+runCollectErrs :: Applicative f => CollectErrsT f Aeson.Value -> f Aeson.Value
+runCollectErrs = fmap finalD
+  where finalD (dat,errs) =
+          Aeson.object $
+          if null errs
+            then [("data",dat)]
+            else [("data",dat),("errors",Aeson.toJSON $ reverse errs)]

--- a/Data/GraphQL/Error.hs
+++ b/Data/GraphQL/Error.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Data.GraphQL.Error (
+  queryError,
+  parseError
+  ) where
+
+import Prelude hiding (error)
+
+import Control.Applicative (Alternative, pure)
+
+import qualified Data.Aeson as Aeson
+import Data.Text
+
+import Data.GraphQL.AST
+import Data.GraphQL.Schema (Schema(..))
+import qualified Data.GraphQL.Schema as Schema
+
+import Data.GraphQL.Encoder (document)
+
+import Debug.Trace
+
+{- | queryError is called when the schema returns no data,
+     and returns an error message.
+-}
+queryError ::
+  Alternative f =>
+  Schema.Schema f -> Schema.Subs -> Document -> f Aeson.Value
+queryError schema@(Schema resolvs) subs doc =
+  pure $  Aeson.object [("errors", Aeson.String errs )]
+  where errs = document $ traceShowId doc
+
+
+parseError :: (Alternative m, Monad m) => String -> m Aeson.Value
+parseError s = pure $ Aeson.object [("errors", Aeson.toJSON [Aeson.object [("message", Aeson.toJSON s)]])]

--- a/Data/GraphQL/Error.hs
+++ b/Data/GraphQL/Error.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Data.GraphQL.Error (
   parseError,
@@ -14,38 +15,45 @@ import Data.Text (Text, pack)
 
 import Control.Arrow ((&&&))
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative (Applicative, pure)
+import Data.Foldable (Foldable, concatMap)
+import Prelude hiding (concatMap)
+#endif
 
 -- | Wraps a parse error into a list of errors.
 parseError :: Applicative f => String -> f Aeson.Value
 parseError s =
   pure $ Aeson.object [("errors", Aeson.toJSON [makeErrorMsg $ pack s])]
 
+-- | A wrapper for an applicative functor, for passing around error messages.
 type CollectErrsT f a = f (a,[Aeson.Value])
 
-
+-- | Takes a (wrapped) list (foldable functor) of values and errors and
+--   joins the values into a list and concatenates the errors.
 joinErrs
-  :: (Applicative m, Functor f, Foldable f)
+  :: (Functor m, Functor f, Foldable f)
   => m (f (a,[Aeson.Value])) -> CollectErrsT m (f a)
 joinErrs = fmap $ fmap fst &&& concatMap snd
 
 -- | Wraps the given applicative to handle errors
-errWrap :: Applicative f => f a -> f (a, [Aeson.Value])
+errWrap :: Functor f => f a -> f (a, [Aeson.Value])
 errWrap = fmap (flip (,) [])
 
 -- | Adds an error to the list of errors.
-addErr :: Applicative f => Aeson.Value -> CollectErrsT f a -> CollectErrsT f a
+addErr :: Functor f => Aeson.Value -> CollectErrsT f a -> CollectErrsT f a
 addErr v = (fmap . fmap) (v :)
 
 makeErrorMsg :: Text -> Aeson.Value
 makeErrorMsg s = Aeson.object [("message",Aeson.toJSON s)]
 
 -- | Convenience function for just wrapping an error message.
-addErrMsg :: Applicative f => Text -> CollectErrsT f a -> CollectErrsT f a
+addErrMsg :: Functor f => Text -> CollectErrsT f a -> CollectErrsT f a
 addErrMsg = addErr . makeErrorMsg
 
 -- | Runs the given query computation, but collects the errors into an error
 --  list, which is then sent back with the data.
-runCollectErrs :: Applicative f => CollectErrsT f Aeson.Value -> f Aeson.Value
+runCollectErrs :: Functor f => CollectErrsT f Aeson.Value -> f Aeson.Value
 runCollectErrs = fmap finalD
   where finalD (dat,errs) =
           Aeson.object $

--- a/Data/GraphQL/Execute.hs
+++ b/Data/GraphQL/Execute.hs
@@ -5,6 +5,7 @@ module Data.GraphQL.Execute (execute) where
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 #endif
+import Control.Applicative (Alternative)
 import Data.Maybe (catMaybes)
 
 import qualified Data.Aeson as Aeson
@@ -12,8 +13,6 @@ import qualified Data.Aeson as Aeson
 import Data.GraphQL.AST
 import Data.GraphQL.Schema (Schema(..))
 import qualified Data.GraphQL.Schema as Schema
-
-import Control.Monad
 
 import Data.GraphQL.Error
 
@@ -23,7 +22,7 @@ import Data.GraphQL.Error
      Returns the result of the query against the schema wrapped in a
      "data" field, or errors wrapped in a "errors field".
 -}
-execute :: MonadPlus m
+execute :: Alternative m
   => Schema.Schema m -> Schema.Subs -> Document -> m Aeson.Value
 execute (Schema resolvs) subs doc = runCollectErrs res
   where res = Schema.resolvers resolvs $ rootFields subs doc

--- a/Data/GraphQL/Schema.hs
+++ b/Data/GraphQL/Schema.hs
@@ -22,13 +22,14 @@ module Data.GraphQL.Schema
   ) where
 
 #if !MIN_VERSION_base(4,8,0)
+import Control.Applicative (pure, (<|>))
 import Data.Foldable (foldMap)
 import Data.Traversable (traverse)
 import Data.Monoid (Monoid(mempty,mappend))
 #else
 import Data.Monoid (Alt(Alt,getAlt))
 #endif
-import Control.Applicative ((<|>),pure,empty)
+import Control.Applicative (Alternative(..))
 import Data.Maybe (catMaybes)
 import Data.Foldable (fold)
 
@@ -38,77 +39,77 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Text (Text)
 import qualified Data.Text as T (null, unwords)
 
+import Control.Arrow
 
 import Data.GraphQL.AST
-
-import Control.Monad (MonadPlus)
 import Data.GraphQL.Error
 
-data Schema m = Schema [Resolver m]
+data Schema f = Schema [Resolver f]
 
-type Resolver m = Field -> CollectErrsT m Aeson.Object
+type Resolver f = Field -> CollectErrsT f Aeson.Object
 
 type Subs = Text -> Maybe Text
 
-
-object :: MonadPlus m => Text -> [Resolver m] -> Resolver m
+object :: Alternative f => Text -> [Resolver f] -> Resolver f
 object name resolvs = objectA name $ \case
      [] -> resolvs
      _  -> empty
 
 objectA
-  :: MonadPlus m => Text -> ([Argument] -> [Resolver m]) -> Resolver m
+  :: Alternative f
+  => Text -> ([Argument] -> [Resolver f]) -> Resolver f
 objectA name f fld@(Field _ _ args _ sels) =
     withField name (resolvers (f args) $ fields sels) fld
 
-scalar :: (MonadPlus m,  Aeson.ToJSON a) => Text -> a -> Resolver m
+scalar :: (Alternative f, Aeson.ToJSON a) => Text -> a -> Resolver f
 scalar name s = scalarA name $ \case
     [] -> pure s
     _  -> empty
 
 scalarA
-  :: (MonadPlus m, Aeson.ToJSON a)
-  => Text -> ([Argument] -> m a) -> Resolver m
-scalarA name f fld@(Field _ _ args _ []) = withField name (lift $ f args) fld
+  :: (Alternative f, Aeson.ToJSON a)
+  => Text -> ([Argument] -> f a) -> Resolver f
+scalarA name f fld@(Field _ _ args _ []) = withField name (errWrap $ f args) fld
 scalarA _ _ _ = empty
 
-array :: MonadPlus m => Text -> [[Resolver m]] -> Resolver m
+array :: Alternative f => Text -> [[Resolver f]] -> Resolver f
 array name resolvs = arrayA name $ \case
     [] -> resolvs
     _  -> empty
 
-arrayA :: MonadPlus m => Text -> ([Argument] -> [[Resolver m]]) -> Resolver m
+arrayA
+  :: Alternative f
+  => Text -> ([Argument] -> [[Resolver f]]) -> Resolver f
 arrayA name f fld@(Field _ _ args _ sels) =
-     withField name (traverse (flip resolvers $ fields sels) $ f args) fld
+     withField name (joinErrs $ traverse (flip resolvers $ fields sels) $ f args) fld
 
-enum :: MonadPlus m => Text -> m [Text] -> Resolver m
+enum :: Alternative f => Text -> f [Text] -> Resolver f
 enum name enums = enumA name $ \case
      [] -> enums
      _  -> empty
 
-enumA :: MonadPlus m => Text -> ([Argument] -> m [Text]) -> Resolver m
-enumA name f fld@(Field _ _ args _ []) = withField name (lift $ f args) fld
+enumA :: Alternative f => Text -> ([Argument] -> f [Text]) -> Resolver f
+enumA name f fld@(Field _ _ args _ []) = withField name (errWrap $ f args) fld
 enumA _ _ _ = empty
 
-withField :: (MonadPlus m, Aeson.ToJSON a)
-             => Text -> CollectErrsT m a
-             -> Field -> CollectErrsT m (HashMap Text Aeson.Value)
+withField
+  :: (Alternative f, Aeson.ToJSON a)
+  => Text -> CollectErrsT f a -> Field -> CollectErrsT f (HashMap Text Aeson.Value)
 withField name f (Field alias name' _ _ _) =
      if name == name'
-        then HashMap.singleton aliasOrName . Aeson.toJSON  <$> runAppendErrs f
+        then fmap (first $ HashMap.singleton aliasOrName . Aeson.toJSON) f
         else empty
      where
        aliasOrName = if T.null alias then name' else alias
 
-
-resolvers :: MonadPlus m => [Resolver m] -> [Field] -> CollectErrsT m Aeson.Value
+resolvers :: Alternative f => [Resolver f] -> [Field] -> CollectErrsT f Aeson.Value
 resolvers resolvs =
-    fmap (Aeson.toJSON . fold)
+    fmap (first Aeson.toJSON . fold)
   . traverse (\fld -> (getAlt $ foldMap (Alt . ($ fld)) resolvs) <|> errmsg fld)
-    where errmsg (Field alias name _ _ _) =
-            do addErrMsg $ T.unwords ["field", name, "not resolved."]
-               return $ HashMap.singleton aliasOrName Aeson.Null
-            where aliasOrName = if T.null alias then name else alias
+    where errmsg (Field alias name _ _ _) = addErrMsg msg $ (errWrap . pure) val
+            where val = HashMap.singleton aliasOrName Aeson.Null
+                  msg = T.unwords ["field", name, "not resolved."]
+                  aliasOrName = if T.null alias then name else alias
 
 field :: Selection -> Maybe Field
 field (SelectionField x) = Just x
@@ -120,7 +121,7 @@ fields = catMaybes . fmap field
 #if !MIN_VERSION_base(4,8,0)
 newtype Alt f a = Alt {getAlt :: f a}
 
-instance MonadPlus f => Monoid (Alt f a) where
+instance Alternative f => Monoid (Alt f a) where
         mempty = Alt empty
         Alt x `mappend` Alt y = Alt $ x <|> y
 #endif

--- a/Data/GraphQL/Schema.hs
+++ b/Data/GraphQL/Schema.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 module Data.GraphQL.Schema
   ( Schema(..)
@@ -21,14 +22,13 @@ module Data.GraphQL.Schema
   ) where
 
 #if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (pure, (<|>))
 import Data.Foldable (foldMap)
 import Data.Traversable (traverse)
 import Data.Monoid (Monoid(mempty,mappend))
 #else
 import Data.Monoid (Alt(Alt,getAlt))
 #endif
-import Control.Applicative (Alternative, empty)
+import Control.Applicative ((<|>),pure,empty)
 import Data.Maybe (catMaybes)
 import Data.Foldable (fold)
 
@@ -36,72 +36,79 @@ import qualified Data.Aeson as Aeson
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Text (Text)
-import qualified Data.Text as T (null)
+import qualified Data.Text as T (null, unwords)
+
 
 import Data.GraphQL.AST
 
-data Schema f = Schema [Resolver f]
+import Control.Monad (MonadPlus)
+import Data.GraphQL.Error
 
-type Resolver  f = Field -> f Aeson.Object
+data Schema m = Schema [Resolver m]
+
+type Resolver m = Field -> CollectErrsT m Aeson.Object
 
 type Subs = Text -> Maybe Text
 
-object :: Alternative f => Text -> [Resolver f] -> Resolver f
+
+object :: MonadPlus m => Text -> [Resolver m] -> Resolver m
 object name resolvs = objectA name $ \case
      [] -> resolvs
      _  -> empty
 
 objectA
-  :: Alternative f
-  => Text -> ([Argument] -> [Resolver f]) -> Resolver f
+  :: MonadPlus m => Text -> ([Argument] -> [Resolver m]) -> Resolver m
 objectA name f fld@(Field _ _ args _ sels) =
     withField name (resolvers (f args) $ fields sels) fld
 
-scalar :: (Alternative f, Aeson.ToJSON a) => Text -> a -> Resolver f
+scalar :: (MonadPlus m,  Aeson.ToJSON a) => Text -> a -> Resolver m
 scalar name s = scalarA name $ \case
     [] -> pure s
     _  -> empty
 
 scalarA
-  :: (Alternative f, Aeson.ToJSON a)
-  => Text -> ([Argument] -> f a) -> Resolver f
-scalarA name f fld@(Field _ _ args _ []) = withField name (f args) fld
+  :: (MonadPlus m, Aeson.ToJSON a)
+  => Text -> ([Argument] -> m a) -> Resolver m
+scalarA name f fld@(Field _ _ args _ []) = withField name (lift $ f args) fld
 scalarA _ _ _ = empty
 
-array :: Alternative f => Text -> [[Resolver f]] -> Resolver f
+array :: MonadPlus m => Text -> [[Resolver m]] -> Resolver m
 array name resolvs = arrayA name $ \case
     [] -> resolvs
     _  -> empty
 
-arrayA
-  :: Alternative f
-  => Text -> ([Argument] -> [[Resolver f]]) -> Resolver f
+arrayA :: MonadPlus m => Text -> ([Argument] -> [[Resolver m]]) -> Resolver m
 arrayA name f fld@(Field _ _ args _ sels) =
      withField name (traverse (flip resolvers $ fields sels) $ f args) fld
 
-enum :: Alternative f => Text -> f [Text] -> Resolver f
+enum :: MonadPlus m => Text -> m [Text] -> Resolver m
 enum name enums = enumA name $ \case
      [] -> enums
      _  -> empty
 
-enumA :: Alternative f => Text -> ([Argument] -> f [Text]) -> Resolver f
-enumA name f fld@(Field _ _ args _ []) = withField name (f args) fld
+enumA :: MonadPlus m => Text -> ([Argument] -> m [Text]) -> Resolver m
+enumA name f fld@(Field _ _ args _ []) = withField name (lift $ f args) fld
 enumA _ _ _ = empty
 
-withField
-  :: (Alternative f, Aeson.ToJSON a)
-  => Text -> f a -> Field -> f (HashMap Text Aeson.Value)
+withField :: (MonadPlus m, Aeson.ToJSON a)
+             => Text -> CollectErrsT m a
+             -> Field -> CollectErrsT m (HashMap Text Aeson.Value)
 withField name f (Field alias name' _ _ _) =
      if name == name'
-        then fmap (HashMap.singleton aliasOrName . Aeson.toJSON) f
+        then HashMap.singleton aliasOrName . Aeson.toJSON  <$> runAppendErrs f
         else empty
      where
        aliasOrName = if T.null alias then name' else alias
 
-resolvers :: Alternative f => [Resolver f] -> [Field] -> f Aeson.Value
+
+resolvers :: MonadPlus m => [Resolver m] -> [Field] -> CollectErrsT m Aeson.Value
 resolvers resolvs =
     fmap (Aeson.toJSON . fold)
-  . traverse (\fld -> getAlt $ foldMap (Alt . ($ fld)) resolvs)
+  . traverse (\fld -> (getAlt $ foldMap (Alt . ($ fld)) resolvs) <|> errmsg fld)
+    where errmsg (Field alias name _ _ _) =
+            do addErrMsg $ T.unwords ["field", name, "not resolved."]
+               return $ HashMap.singleton aliasOrName Aeson.Null
+            where aliasOrName = if T.null alias then name else alias
 
 field :: Selection -> Maybe Field
 field (SelectionField x) = Just x
@@ -113,7 +120,7 @@ fields = catMaybes . fmap field
 #if !MIN_VERSION_base(4,8,0)
 newtype Alt f a = Alt {getAlt :: f a}
 
-instance Alternative f => Monoid (Alt f a) where
+instance MonadPlus f => Monoid (Alt f a) where
         mempty = Alt empty
         Alt x `mappend` Alt y = Alt $ x <|> y
 #endif

--- a/graphql.cabal
+++ b/graphql.cabal
@@ -28,6 +28,7 @@ library
                        Data.GraphQL.Execute
                        Data.GraphQL.Schema
                        Data.GraphQL.Parser
+                       Data.GraphQL.Error
   build-depends:       base >= 4.7 && < 5,
                        text >= 0.11.3.1,
                        aeson >= 0.7.0.3,

--- a/graphql.cabal
+++ b/graphql.cabal
@@ -14,7 +14,7 @@ copyright:           Copyright (C) 2015-2016 J. Daniel Navarro
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 7.8.4, GHC == 7.10.3
+tested-with:         GHC == 7.10.3
 extra-source-files:  README.md CHANGELOG.md stack.yaml
 data-files:          tests/data/*.graphql
                      tests/data/*.min.graphql
@@ -29,10 +29,11 @@ library
                        Data.GraphQL.Schema
                        Data.GraphQL.Parser
                        Data.GraphQL.Error
-  build-depends:       base >= 4.7 && < 5,
-                       text >= 0.11.3.1,
-                       aeson >= 0.7.0.3,
+  build-depends:       aeson >= 0.7.0.3,
                        attoparsec >= 0.10.4.0,
+                       base >= 4.8 && < 5,
+                       mtl >= 2.2.1,
+                       text >= 0.11.3.1,
                        unordered-containers >= 0.2.5.0
 
 test-suite tasty
@@ -45,15 +46,16 @@ test-suite tasty
                        Test.StarWars.Data
                        Test.StarWars.Schema
                        Test.StarWars.QueryTests
-  build-depends:       base >= 4.6 && <5,
-                       aeson >= 0.7.0.3,
-                       text >= 0.11.3.1,
+  build-depends:       aeson >= 0.7.0.3,
                        attoparsec >= 0.10.4.0,
+                       base >= 4.7 && <5,
+                       graphql,
+                       mtl >= 2.2.1,
                        raw-strings-qq >= 1.1,
                        tasty >= 0.10,
                        tasty-hunit >= 0.9,
-                       unordered-containers >= 0.2.5.0,
-                       graphql
+                       text >= 0.11.3.1,
+                       unordered-containers >= 0.2.5.0
 
 source-repository head
   type:     git

--- a/graphql.cabal
+++ b/graphql.cabal
@@ -14,7 +14,7 @@ copyright:           Copyright (C) 2015-2016 J. Daniel Navarro
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 7.10.3
+tested-with:         GHC == 7.8.4, GHC == 7.10.3
 extra-source-files:  README.md CHANGELOG.md stack.yaml
 data-files:          tests/data/*.graphql
                      tests/data/*.min.graphql

--- a/graphql.cabal
+++ b/graphql.cabal
@@ -31,8 +31,7 @@ library
                        Data.GraphQL.Error
   build-depends:       aeson >= 0.7.0.3,
                        attoparsec >= 0.10.4.0,
-                       base >= 4.8 && < 5,
-                       mtl >= 2.2.1,
+                       base >= 4.7 && < 5,
                        text >= 0.11.3.1,
                        unordered-containers >= 0.2.5.0
 
@@ -48,9 +47,8 @@ test-suite tasty
                        Test.StarWars.QueryTests
   build-depends:       aeson >= 0.7.0.3,
                        attoparsec >= 0.10.4.0,
-                       base >= 4.7 && <5,
+                       base >= 4.6 && <5,
                        graphql,
-                       mtl >= 2.2.1,
                        raw-strings-qq >= 1.1,
                        tasty >= 0.10,
                        tasty-hunit >= 0.9,

--- a/tests/Test/StarWars/QueryTests.hs
+++ b/tests/Test/StarWars/QueryTests.hs
@@ -222,5 +222,5 @@ testQuery q expected = graphql schema q @?= Just expected
 testQueryParams :: Subs -> Text -> Aeson.Value -> Assertion
 testQueryParams f q expected = graphqlSubs schema f q @?= Just expected
 
-testFailParams :: Subs -> Text -> Assertion
-testFailParams f q = graphqlSubs schema f q @?= Nothing
+-- testFailParams :: Subs -> Text -> Assertion
+-- testFailParams f q = graphqlSubs schema f q @?= Nothing

--- a/tests/Test/StarWars/QueryTests.hs
+++ b/tests/Test/StarWars/QueryTests.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Test.StarWars.QueryTests (test) where
 
-import qualified Data.Aeson as Aeson (Value,Value(Null), toJSON)
+import qualified Data.Aeson as Aeson (Value(Null), toJSON)
 import Data.Aeson (object, (.=))
 import Data.Text (Text)
 import Text.RawString.QQ (r)

--- a/tests/Test/StarWars/QueryTests.hs
+++ b/tests/Test/StarWars/QueryTests.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Test.StarWars.QueryTests (test) where
 
-import qualified Data.Aeson as Aeson (Value)
+import qualified Data.Aeson as Aeson (Value,Value(Null), toJSON)
 import Data.Aeson (object, (.=))
 import Data.Text (Text)
 import Text.RawString.QQ (r)
@@ -28,7 +28,7 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object ["hero" .= object ["id" .= ("2001" :: Text)]]
+      $ object [ "data" .= object ["hero" .= object ["id" .= ("2001" :: Text)]]]
     , testCase "R2-D2 ID and friends" . testQuery
         [r| query HeroNameAndFriendsQuery {
               hero {
@@ -40,7 +40,7 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
           "hero" .= object [
               "id" .= ("2001" :: Text)
             , "name" .= ("R2-D2" :: Text)
@@ -50,7 +50,7 @@ test = testGroup "Star Wars Query Tests"
                 , object ["name" .= ("Leia Organa" :: Text)]
                 ]
             ]
-        ]
+        ]]
     ]
   , testGroup "Nested Queries"
     [ testCase "R2-D2 friends" . testQuery
@@ -67,7 +67,7 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
           "hero" .= object [
               "name" .= ("R2-D2" :: Text)
             , "friends" .= [
@@ -102,7 +102,7 @@ test = testGroup "Star Wars Query Tests"
                     ]
                 ]
             ]
-        ]
+        ]]
     , testCase "Luke ID" . testQuery
         [r| query FetchLukeQuery {
               human(id: "1000") {
@@ -110,12 +110,12 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
           "human" .= object [
              "name" .= ("Luke Skywalker" :: Text)
           ]
         ]
-    ]
+    ]]
     , testCase "Luke ID with variable" . testQueryParams
          (\v -> if v == "someId"
                    then Just "1000"
@@ -126,9 +126,9 @@ test = testGroup "Star Wars Query Tests"
                }
              }
          |]
-      $ object [
+      $ object [ "data" .= object [
           "human" .= object ["name" .= ("Luke Skywalker" :: Text)]
-        ]
+        ]]
     , testCase "Han ID with variable" . testQueryParams
         (\v -> if v == "someId"
                   then Just "1002"
@@ -139,10 +139,10 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
           "human" .= object ["name" .= ("Han Solo" :: Text)]
-        ]
-    , testCase "Invalid ID" $ testFailParams
+        ]]
+    , testCase "Invalid ID" . testQueryParams
         (\v -> if v == "id"
                   then Just "Not a valid ID"
                   else Nothing)
@@ -151,13 +151,14 @@ test = testGroup "Star Wars Query Tests"
                 name
               }
             }
-        |]
+        |] $ object ["data" .= object ["human" .= object ["name" .= Aeson.Null]],
+                     "errors" .= (Aeson.toJSON [object ["message" .= ("field name not resolved." :: Text)]])]
         -- TODO: This test is directly ported from `graphql-js`, however do we want
         -- to mimic the same behavior? Is this part of the spec? Once proper
         -- exceptions are implemented this test might no longer be meaningful.
         -- If the same behavior needs to be replicated, should it be implemented
         -- when defining the `Schema` or when executing?
-        -- $ object ["human" .= Aeson.Null]
+        -- $ object [ "data" .= object ["human" .= Aeson.Null] ]
     , testCase "Luke aliased" . testQuery
         [r| query FetchLukeAliased {
               luke: human(id: "1000") {
@@ -165,11 +166,11 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
          "luke" .= object [
            "name" .= ("Luke Skywalker" :: Text)
            ]
-        ]
+        ]]
     , testCase "R2-D2 ID and friends aliased" . testQuery
         [r| query HeroNameAndFriendsQuery {
               hero {
@@ -181,7 +182,7 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
           "hero" .= object [
               "id" .= ("2001" :: Text)
             , "name" .= ("R2-D2" :: Text)
@@ -191,7 +192,7 @@ test = testGroup "Star Wars Query Tests"
                 , object ["friendName" .= ("Leia Organa" :: Text)]
                 ]
             ]
-        ]
+        ]]
     , testCase "Luke and Leia aliased" . testQuery
         [r| query FetchLukeAndLeiaAliased {
               luke: human(id: "1000") {
@@ -202,14 +203,14 @@ test = testGroup "Star Wars Query Tests"
               }
             }
         |]
-      $ object [
+      $ object [ "data" .= object [
           "luke" .= object [
             "name" .= ("Luke Skywalker" :: Text)
            ]
         , "leia" .= object [
             "name" .= ("Leia Organa" :: Text)
            ]
-        ]
+        ]]
   ]
 
 testQuery :: Text -> Aeson.Value -> Assertion

--- a/tests/Test/StarWars/Schema.hs
+++ b/tests/Test/StarWars/Schema.hs
@@ -13,31 +13,30 @@ import Data.GraphQL.Schema
 import qualified Data.GraphQL.Schema as Schema
 
 import Test.StarWars.Data
-import Control.Monad
 
 -- * Schema
 -- See https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsSchema.js
 
-schema :: MonadPlus f => Schema f
+schema :: Alternative f => Schema f
 schema = Schema [hero, human, droid]
 
-hero :: MonadPlus f => Resolver f
+hero :: Alternative f => Resolver f
 hero = Schema.objectA "hero" $ \case
   [] -> character artoo
   [Argument "episode" (ValueInt n)] -> character $ getHero (fromIntegral n)
   _ -> empty
 
-human :: MonadPlus f => Resolver f
+human :: Alternative f => Resolver f
 human = Schema.objectA "human" $ \case
   [Argument "id" (ValueString i)] -> character =<< getHuman i
   _ -> empty
 
-droid :: MonadPlus f => Resolver f
+droid :: Alternative f => Resolver f
 droid = Schema.objectA "droid" $ \case
    [Argument "id" (ValueString i)] -> character =<< getDroid i
    _ -> empty
 
-character :: MonadPlus f => Character -> [Resolver f]
+character :: Alternative f => Character -> [Resolver f]
 character char =
   [ Schema.scalar "id"        $ id_ char
   , Schema.scalar "name"      $ name char

--- a/tests/Test/StarWars/Schema.hs
+++ b/tests/Test/StarWars/Schema.hs
@@ -13,30 +13,31 @@ import Data.GraphQL.Schema
 import qualified Data.GraphQL.Schema as Schema
 
 import Test.StarWars.Data
+import Control.Monad
 
 -- * Schema
 -- See https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsSchema.js
 
-schema :: Alternative f => Schema f
+schema :: MonadPlus f => Schema f
 schema = Schema [hero, human, droid]
 
-hero :: Alternative f => Resolver f
+hero :: MonadPlus f => Resolver f
 hero = Schema.objectA "hero" $ \case
   [] -> character artoo
   [Argument "episode" (ValueInt n)] -> character $ getHero (fromIntegral n)
   _ -> empty
 
-human :: Alternative f => Resolver f
+human :: MonadPlus f => Resolver f
 human = Schema.objectA "human" $ \case
   [Argument "id" (ValueString i)] -> character =<< getHuman i
   _ -> empty
 
-droid :: Alternative f => Resolver f
+droid :: MonadPlus f => Resolver f
 droid = Schema.objectA "droid" $ \case
    [Argument "id" (ValueString i)] -> character =<< getDroid i
    _ -> empty
 
-character :: Alternative f => Character -> [Resolver f]
+character :: MonadPlus f => Character -> [Resolver f]
 character char =
   [ Schema.scalar "id"        $ id_ char
   , Schema.scalar "name"      $ name char


### PR DESCRIPTION
This pull request adds basic error handling to the execute function, adding to the error list messages when a field does not resolve or when a query does not parse. This changes the output to be of the form
`{ data: ...}` for only data, and `{data: ..., errors: [...]}` when there are errors, mimicking the example on [`graphql-js`](https://github.com/graphql/graphql-js). It is implemented via `Functor`, so it does not impose any further constraints on the schema.