### PR TITLE
Fix __typename related test cases

### DIFF
--- a/tests/Test/StarWars/Data.hs
+++ b/tests/Test/StarWars/Data.hs
@@ -62,6 +62,10 @@ secretBackstory = error "secretBackstory is secret."
 luke :: Character
 luke = Right luke'
 
+typename :: Character -> Text
+typename (Left _)  = "Droid"
+typename (Right _) = "Human"
+
 luke' :: Human
 luke' = Human
   { _humanChar = CharCommon

--- a/tests/Test/StarWars/QueryTests.hs
+++ b/tests/Test/StarWars/QueryTests.hs
@@ -251,18 +251,18 @@ test = testGroup "Star Wars Query Tests"
             }
           |]
     $ object ["data" .= object [
-        "hero" .= ["__typename" .= ("Droid" :: Text), r2d2Name]
+        "hero" .= object ["__typename" .= ("Droid" :: Text), r2d2Name]
       ]]
     , testCase "Luke is a human" . testQuery
         [r| query CheckTypeOfLuke {
-              hero(episode: EMPIRE) {
+              hero(episode: 5) {
                 __typename
                 name
               }
             }
           |]
     $ object ["data" .= object [
-        "hero" .= ["__typename" .= ("Human" :: Text), lukeName]
+        "hero" .= object ["__typename" .= ("Human" :: Text), lukeName]
       ]]
     ]
     , testGroup "Errors in resolvers"

--- a/tests/Test/StarWars/Schema.hs
+++ b/tests/Test/StarWars/Schema.hs
@@ -43,4 +43,5 @@ character char =
   , Schema.array  "friends"   $ character <$> getFriends char
   , Schema.enum   "appearsIn" . traverse getEpisode $ appearsIn char
   , Schema.scalar   "secretBackstory" $ secretBackstory char
+  , Schema.scalar "__typename" $ typename char
   ]


### PR DESCRIPTION
This fixes the two test cases related to typename.

Should we make `__typename` and other type-system related information explicit and required for `object` schemas?

I also had to change this line, because it is checking for `ValueInt` value for that argument.
```
-              hero(episode: EMPIRE) {
+              hero(episode: 5) {
```
Should we add stricter type-checking for our StarWars schema?

Forgive my lack of knowledge, I just started with GraphQL. The Javascript schema-definition API seems very explicit, maybe we should aim for that here as well?