### PR TITLE
Parse number as scientific and interpret meaning separately.

### DIFF
--- a/graphql.cabal
+++ b/graphql.cabal
@@ -34,7 +34,8 @@ library
                        attoparsec >= 0.10.4.0,
                        base >= 4.7 && < 5,
                        text >= 0.11.3.1,
-                       unordered-containers >= 0.2.5.0
+                       unordered-containers >= 0.2.5.0,
+                       scientific >=0.3.1 && <0.4
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
   else


### PR DESCRIPTION
The current parser will fail parsing floats because it parses an int,
and then stumbles on the dot.

To fix I interpret the value with the scientific library which already
is a dependency through attoparsec, so we're not introducing any extra
downloads or compiling.

I think this is still subtly wrong because "10.0" will be parsed as
ValueInt, but because input argument ints are allowed to be coerced
into doubles (according to the spec) this is probably acceptable.