### PR TITLE
Fixed 'TODO' in parser re: Integer bounds

### DIFF
--- a/Data/GraphQL/AST.hs
+++ b/Data/GraphQL/AST.hs
@@ -17,7 +17,6 @@ newtype Document = Document [Definition] deriving (Eq,Show)
 
 data Definition = DefinitionOperation OperationDefinition
                 | DefinitionFragment  FragmentDefinition
-                | DefinitionType      TypeDefinition
                   deriving (Eq,Show)
 
 data OperationDefinition = Query    Node
@@ -127,48 +126,3 @@ newtype ListType = ListType Type deriving (Eq,Show)
 data NonNullType = NonNullTypeNamed NamedType
                  | NonNullTypeList  ListType
                    deriving (Eq,Show)
-
--- * Type definition
-
-data TypeDefinition = TypeDefinitionObject        ObjectTypeDefinition
-                    | TypeDefinitionInterface     InterfaceTypeDefinition
-                    | TypeDefinitionUnion         UnionTypeDefinition
-                    | TypeDefinitionScalar        ScalarTypeDefinition
-                    | TypeDefinitionEnum          EnumTypeDefinition
-                    | TypeDefinitionInputObject   InputObjectTypeDefinition
-                    | TypeDefinitionTypeExtension TypeExtensionDefinition
-                      deriving (Eq,Show)
-
-data ObjectTypeDefinition = ObjectTypeDefinition Name Interfaces [FieldDefinition]
-                            deriving (Eq,Show)
-
-type Interfaces = [NamedType]
-
-data FieldDefinition = FieldDefinition Name ArgumentsDefinition Type
-                       deriving (Eq,Show)
-
-type ArgumentsDefinition = [InputValueDefinition]
-
-data InputValueDefinition = InputValueDefinition Name Type (Maybe DefaultValue)
-                            deriving (Eq,Show)
-
-data InterfaceTypeDefinition = InterfaceTypeDefinition Name [FieldDefinition]
-                               deriving (Eq,Show)
-
-data UnionTypeDefinition = UnionTypeDefinition Name [NamedType]
-                           deriving (Eq,Show)
-
-newtype ScalarTypeDefinition = ScalarTypeDefinition Name
-                            deriving (Eq,Show)
-
-data EnumTypeDefinition = EnumTypeDefinition Name [EnumValueDefinition]
-                          deriving (Eq,Show)
-
-newtype EnumValueDefinition = EnumValueDefinition Name
-                              deriving (Eq,Show)
-
-data InputObjectTypeDefinition = InputObjectTypeDefinition Name [InputValueDefinition]
-                                 deriving (Eq,Show)
-
-newtype TypeExtensionDefinition = TypeExtensionDefinition ObjectTypeDefinition
-                                  deriving (Eq,Show)

--- a/Data/GraphQL/AST/Core.hs
+++ b/Data/GraphQL/AST/Core.hs
@@ -1,0 +1,30 @@
+-- | This is the AST meant to be executed.
+module Data.GraphQL.AST.Core where
+
+import Data.List.NonEmpty (NonEmpty)
+
+import Data.Text (Text)
+
+newtype Name = Name Text deriving (Eq,Show)
+
+newtype Document = Document (NonEmpty Operation) deriving (Eq,Show)
+
+data Operation = Query (NonEmpty Field)
+               | Mutation (NonEmpty Field)
+                 deriving (Eq,Show)
+
+data Field = Field Name [Argument] [Field] deriving (Eq,Show)
+
+data Argument = Argument Name Value deriving (Eq,Show)
+
+data Value = ValueInt Int32
+           -- GraphQL Float is double precision
+           | ValueFloat Double
+           | ValueBoolean Bool
+           | ValueString Text
+           | ValueEnum Name
+           | ValueList [Value]
+           | ValueObject [ObjectField]
+             deriving (Eq,Show)
+
+data ObjectField = ObjectField Name Value deriving (Eq,Show)

--- a/Data/GraphQL/Encoder.hs
+++ b/Data/GraphQL/Encoder.hs
@@ -17,7 +17,6 @@ document (Document defs) = (`snoc` '\n') . mconcat $ definition <$> defs
 definition :: Definition -> Text
 definition (DefinitionOperation x) = operationDefinition x
 definition (DefinitionFragment  x) = fragmentDefinition x
-definition (DefinitionType      x) = typeDefinition x
 
 operationDefinition :: OperationDefinition -> Text
 operationDefinition (Query    n) = "query "    <> node n
@@ -138,73 +137,6 @@ listType (ListType ty) = brackets (type_ ty)
 nonNullType :: NonNullType -> Text
 nonNullType (NonNullTypeNamed (NamedType x)) = x <> "!"
 nonNullType (NonNullTypeList  x) = listType x <> "!"
-
-typeDefinition :: TypeDefinition -> Text
-typeDefinition (TypeDefinitionObject        x) = objectTypeDefinition x
-typeDefinition (TypeDefinitionInterface     x) = interfaceTypeDefinition x
-typeDefinition (TypeDefinitionUnion         x) = unionTypeDefinition x
-typeDefinition (TypeDefinitionScalar        x) = scalarTypeDefinition x
-typeDefinition (TypeDefinitionEnum          x) = enumTypeDefinition x
-typeDefinition (TypeDefinitionInputObject   x) = inputObjectTypeDefinition x
-typeDefinition (TypeDefinitionTypeExtension x) = typeExtensionDefinition x
-
-objectTypeDefinition :: ObjectTypeDefinition -> Text
-objectTypeDefinition (ObjectTypeDefinition name ifaces fds) =
-    "type " <> name
-            <> optempty (spaced . interfaces) ifaces
-            <> optempty fieldDefinitions fds
-
-interfaces :: Interfaces -> Text
-interfaces = ("implements " <>) . spaces namedType
-
-fieldDefinitions :: [FieldDefinition] -> Text
-fieldDefinitions = bracesCommas fieldDefinition
-
-fieldDefinition :: FieldDefinition -> Text
-fieldDefinition (FieldDefinition name args ty) =
-    name <> optempty argumentsDefinition args
-         <> ":"
-         <> type_ ty
-
-argumentsDefinition :: ArgumentsDefinition -> Text
-argumentsDefinition = parensCommas inputValueDefinition
-
-interfaceTypeDefinition :: InterfaceTypeDefinition -> Text
-interfaceTypeDefinition (InterfaceTypeDefinition name fds) =
-    "interface " <> name <> fieldDefinitions fds
-
-unionTypeDefinition :: UnionTypeDefinition -> Text
-unionTypeDefinition (UnionTypeDefinition name ums) =
-    "union " <> name <> "=" <> unionMembers ums
-
-unionMembers :: [NamedType] -> Text
-unionMembers = intercalate "|" . fmap namedType
-
-scalarTypeDefinition :: ScalarTypeDefinition -> Text
-scalarTypeDefinition (ScalarTypeDefinition name) = "scalar " <> name
-
-enumTypeDefinition :: EnumTypeDefinition -> Text
-enumTypeDefinition (EnumTypeDefinition name evds) =
-    "enum " <> name
-            <> bracesCommas enumValueDefinition evds
-
-enumValueDefinition :: EnumValueDefinition -> Text
-enumValueDefinition (EnumValueDefinition name) = name
-
-inputObjectTypeDefinition :: InputObjectTypeDefinition -> Text
-inputObjectTypeDefinition (InputObjectTypeDefinition name ivds) =
-    "input " <> name <> inputValueDefinitions ivds
-
-inputValueDefinitions :: [InputValueDefinition] -> Text
-inputValueDefinitions = bracesCommas inputValueDefinition
-
-inputValueDefinition :: InputValueDefinition -> Text
-inputValueDefinition (InputValueDefinition name ty dv) =
-    name <> ":" <> type_ ty <> maybe mempty defaultValue dv
-
-typeExtensionDefinition :: TypeExtensionDefinition -> Text
-typeExtensionDefinition (TypeExtensionDefinition otd) =
-    "extend " <> objectTypeDefinition otd
 
 -- * Internal
 


### PR DESCRIPTION
I changed `ValueInt Int32` to `ValueInt Integer` and then handled bounds checking in the parser.

The problem with using `Int32` is that `floatingOrInteger` doesn't behave well in conjunction with `scientific` when constrained to `Int32` -- we get a nonsense overflow number when the number parsed by `scientific` is out of the `Int32` range.